### PR TITLE
Fix narrow tables shadow

### DIFF
--- a/src/assets/stylesheets/main/_typeset.scss
+++ b/src/assets/stylesheets/main/_typeset.scss
@@ -615,7 +615,6 @@ kbd {
     // Data tables
     html & table {
       display: table;
-      width: 100%;
       margin: 0;
       overflow: hidden;
     }


### PR DESCRIPTION
Fixes #13.

<img width="683" alt="Screen Shot 2021-01-06 at 16 18 49" src="https://user-images.githubusercontent.com/38889364/103810949-dd88fe00-503a-11eb-938d-06d65c09dfed.png">

This example can be found at [`/customization/`](http://localhost:8000/customization/) of this documentation.