### PR TITLE
Disable doc build/deploy on main and keep it only on master

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ name: documentation
 on:
   push:
     branches:
-      - main
+      - master
 
 env:
   PYTHON_VERSION: 3.x


### PR DESCRIPTION
Test proposed by @ldez so we don't need to keep the material dir on the repo.