### PR TITLE
Remove webpack section breaks template paths and update build assets

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -1,7 +1,7 @@
 {#-
   This file was automatically generated - do not edit
 -#}
-{% import "partials/partials/language.html" as lang with context %}
+{% import "partials/language.html" as lang with context %}
 <!doctype html>
 <html lang="{{ lang.t('language') }}" class="no-js">
   <head>
@@ -27,7 +27,7 @@
         <meta name="author" content="{{ config.site_author }}">
       {% endif %}
       <link rel="shortcut icon" href="{{ config.theme.favicon | url }}">
-      <meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-traefiklabs-100.0.2">
+      <meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-traefiklabs-100.0.3">
     {% endblock %}
     {% block htmltitle %}
       {% if page and page.meta and page.meta.title %}
@@ -39,12 +39,12 @@
       {% endif %}
     {% endblock %}
     {% block styles %}
-      <link rel="stylesheet" href="{{ 'assets/stylesheets/main.92b813f4.min.css' | url }}">
+      <link rel="stylesheet" href="{{ 'assets/stylesheets/main.css' | url }}">
       {% if config.theme.palette %}
         {% set palette = config.theme.palette %}
-        <link rel="stylesheet" href="{{ 'assets/stylesheets/palette.a44cd350.min.css' | url }}">
+        <link rel="stylesheet" href="{{ 'assets/stylesheets/palette.css' | url }}">
         {% if palette.primary %}
-          {% import "partials/partials/palette.html" as map %}
+          {% import "partials/palette.html" as map %}
           {% set primary = map.primary(
             palette.primary | replace(" ", "-") | lower
           ) %}
@@ -72,7 +72,7 @@
     {% endfor %}
     {% block analytics %}
       {% if config.google_analytics %}
-        {% include "partials/integrations/partials/integrations/analytipartials/language/cs.html" %}
+        {% include "partials/integrations/analytics.html" %}
       {% endif %}
     {% endblock %}
     {% block extrahead %}{% endblock %}
@@ -105,8 +105,8 @@
       {% endif %}
     </div>
     {% block header %}
-      {% include "partials/partials/company-partials/header.html" %}
-      {% include "partials/partials/header.html" %}
+      {% include "partials/company-header.html" %}
+      {% include "partials/header.html" %}
     {% endblock %}
     <div class="md-container" data-md-component="container">
       <main class="md-main" data-md-component="main">
@@ -114,14 +114,14 @@
           {% block site_nav %}
             {% if nav %}
               <div class="md-sidebar md-sidebar--primary" data-md-component="navigation">
-                {% include "partials/partials/product-switcher.html" %}
-                {% include "partials/partials/search.html" %}
+                {% include "partials/product-switcher.html" %}
+                {% include "partials/search.html" %}
                 {% if "search" in config["plugins"] %}
                   <label class="md-icon md-icon--search md-header-nav__button" for="__search"></label>
                 {% endif %}
                 <div class="md-sidebar__scrollwrap">
                   <div class="md-sidebar__inner">
-                  {% include "partials/partials/nav.html" %}
+                  {% include "partials/nav.html" %}
                   </div>
                 </div>
               </div>
@@ -131,13 +131,13 @@
                 {% if config.repo_url %}
                   <div class="md-flex__cell md-flex__cell--shrink repo_url">
                     <div class="md-header-nav__source">
-                      {% include "partials/partials/source.html" %}
+                      {% include "partials/source.html" %}
                     </div>
                   </div>
                 {% endif %}
                 <div class="md-sidebar__scrollwrap">
                   <div class="md-sidebar__inner">
-                    {% include "partials/partials/toc.html" %}
+                    {% include "partials/toc.html" %}
                   </div>
                 </div>
               </div>
@@ -148,7 +148,7 @@
               {% block content %}
                 {% if page.edit_url %}
                   <a href="{{ page.edit_url }}" title="{{ lang.t('edit.link.title') }}" class="md-content__button md-icon">
-                    {% include ".icons/material/.icons/material/pencil.svg" %}
+                    {% include ".icons/material/pencil.svg" %}
                   </a>
                 {% endif %}
                 {% if not "\x3ch1" in page.content %}
@@ -159,24 +159,24 @@
                   {% if page.meta.git_revision_date_localized or
                         page.meta.revision_date
                   %}
-                    {% include "partials/partials/source-date.html" %}
+                    {% include "partials/source-date.html" %}
                   {% endif %}
                 {% endif %}
               {% endblock %}
               {% block disqus %}
-                {% include "partials/integrations/partials/integrations/disqus.html" %}
+                {% include "partials/integrations/disqus.html" %}
               {% endblock %}
             </article>
           </div>
         </div>
       </main>
       {% block footer %}
-        {% include "partials/partials/footer.html" %}
+        {% include "partials/footer.html" %}
       {% endblock %}
     </div>
     {% block scripts %}
-      <script src="{{ 'assets/javascripts/vendor.08c56446.min.js' | url }}"></script>
-      <script src="{{ 'assets/javascripts/bundle.b242f96c.min.js' | url }}"></script>
+      <script src="{{ 'assets/javascripts/vendor.js' | url }}"></script>
+      <script src="{{ 'assets/javascripts/bundle.js' | url }}"></script>
       {%- set translations = {} -%}
       {%- for key in [
         "clipboard.copy",
@@ -204,7 +204,7 @@
           base: "{{ base_url }}",
           features: {{ config.theme.features or [] | tojson }},
           search: Object.assign({
-            worker: "{{ 'assets/javascripts/worker/search.8c7e0a7e.min.js' | url }}"
+            worker: "{{ 'assets/javascripts/worker/search.js' | url }}"
           }, typeof search !== "undefined" && search)
         })
       </script>

--- a/material/overrides/main.html
+++ b/material/overrides/main.html
@@ -22,13 +22,13 @@
   <meta name="twitter:title" content="{{ title }}">
   <meta name="twitter:description" content="{{ config.site_description }}">
   <meta name="twitter:image" content="{{ image }}">
-  <link rel="stylesheet" href="{{ 'assets/stylesheets/overrides.d72bad8a.min.css' | url }}">
+  <link rel="stylesheet" href="{{ 'assets/stylesheets/overrides.css' | url }}">
 {% endblock %}
 {% block announce %}
   <a href="https://twitter.com/squidfunk">
     For updates follow <strong>@squidfunk</strong> on
     <span class="twemoji twitter">
-      {% include ".icons/fontawesome/brands/.icons/material/twitter.svg" %}
+      {% include ".icons/fontawesome/brands/twitter.svg" %}
     </span>
     <strong>Twitter</strong>
   </a>
@@ -39,13 +39,13 @@
     <a href="{{ 'insiders/' | url }}" title="Material for MkDocs Insiders">
       <hr>
       <span class="twemoji">
-        {% include ".icons/.icons/logo.svg" %}
+        {% include ".icons/logo.svg" %}
       </span>
       <span class="twemoji">
-        {% include ".icons/material/.icons/material/plus.svg" %}
+        {% include ".icons/material/plus.svg" %}
       </span>
       <span class="twemoji tx-heart">
-        {% include ".icons/octicons/.icons/octicons/heart-fill-24.svg" %}
+        {% include ".icons/octicons/heart-fill-24.svg" %}
       </span>
       <hr>
     </a>

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -21,14 +21,11 @@
  */
 
 import * as CopyPlugin from "copy-webpack-plugin"
-import * as EventHooksPlugin from "event-hooks-webpack-plugin"
-import * as fs from "fs"
 import { minify as minhtml } from "html-minifier"
 import IgnoreEmitPlugin from "ignore-emit-webpack-plugin"
 import ImageminPlugin from "imagemin-webpack-plugin"
 import MiniCssExtractPlugin = require("mini-css-extract-plugin")
 import * as path from "path"
-import { toPairs } from "ramda"
 import { minify as minjs } from "terser"
 import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin"
 import { Configuration } from "webpack"
@@ -320,29 +317,6 @@ export default (_env: never, args: Configuration): Configuration[] => {
             context: "src",
             ...pattern
           }))
-        }),
-
-        /* Hooks */
-        new EventHooksPlugin({
-          afterEmit: () => {
-
-            /* Replace asset URLs in templates */
-            if (args.mode === "production") {
-              const manifest = require("./material/assets/manifest.json")
-              for (const file of [
-                "material/base.html",
-                "material/overrides/main.html"
-              ]) {
-                const template = toPairs<string>(manifest)
-                  .reduce((content, [from, to]) => {
-                    return content.replace(new RegExp(from, "g"), to)
-                  }, fs.readFileSync(file, "utf8"))
-
-                /* Save template with replaced assets */
-                fs.writeFileSync(file, template, "utf8")
-              }
-            }
-          }
         }),
 
         /* Minify SVGs */


### PR DESCRIPTION
When we run `npm run build`, because of the `production`, flag that is added to the webpack command, it runs a block of code (named [`hooks` on `webpack.config.js` line 325](https://github.com/traefik/mkdocs-material/blob/main/webpack.config.ts#L325-L346)) that blindly replaces everything listed on `material/manifest.json` so it generates broken paths for the templates.

-----
As an example, in the `manifest.json` there's an entry to replace `header.html` to `partials/header.html`, so it does this:
in src: `partials/header.html`
it replaces to: `partials/partials/header.html`

or worse:
in src: `partials/company-header.html`
it replaces to: `partials/partials/company-partials/header.html` <-- special case due to other replacements

-----

I removed that block of code and now I have the Pilot doc with the correct styling (apparently with no other weird bugs).