### PR TITLE
Fixes Get Demo button in header.

### DIFF
--- a/material/partials/company-header.html
+++ b/material/partials/company-header.html
@@ -351,7 +351,8 @@
           {% include ".icons/material/magnify.svg" %}
         </label>
         <div class="site-header__demo-button">
-          <button class="button--secondary">Get a demo</button>
+          <button class="button--secondary"
+            onClick="(function(){window.location.href = 'https://info.traefik.io/en/request-demo-traefik-enterprise'})()">Get a demo</button>
         </div>
       </div>
     </div>

--- a/src/partials/company-header.html
+++ b/src/partials/company-header.html
@@ -531,7 +531,8 @@
           {% include ".icons/material/magnify.svg" %}
         </label>
         <div class="site-header__demo-button">
-          <button class="button--secondary">Get a demo</button>
+          <button class="button--secondary"
+            onClick="(function(){window.location.href = 'https://info.traefik.io/en/request-demo-traefik-enterprise'})()">Get a demo</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The `Get a demo` button is not doing anything, I cannot see any javascript attached to it. This adds the link to the Traefik Enterprise demo request form.