### PR TITLE
Sidebar menus improvements

### DIFF
--- a/src/assets/stylesheets/customizations/_menu.scss
+++ b/src/assets/stylesheets/customizations/_menu.scss
@@ -39,7 +39,7 @@
 }
 
 .md-sidebar--secondary .md-nav__list {
-  padding: 0 0.4rem 0.8rem 1.2rem;
+  padding: 0 0rem 0rem 1.2rem;
 }
 
 .md-sidebar--secondary .md-sidebar__scrollwrap .md-nav__link {

--- a/src/assets/stylesheets/main/layout/_sidebar.scss
+++ b/src/assets/stylesheets/main/layout/_sidebar.scss
@@ -122,12 +122,18 @@ $md-toggle__drawer--checked:
       // Ensure smooth scrolling on iOS
       .md-sidebar__scrollwrap {
         touch-action: pan-y;
+
+        .md-nav__item {
+            padding: 0 0;
+        }
       }
     }
   }
 
   // Wrapper for scrolling on overflow
   &__scrollwrap {
+    // screen height minus (header bar + search bar + product switcher)
+    max-height: calc(100vh - 240px);
     overflow-y: auto;
     // Hack: reduce jitter
     backface-visibility: hidden;


### PR DESCRIPTION
## What does this PR do?

This PR fixes the scrolling bug for sidebar menus, by allowing a maximum height equivalent to the visual height minus the header bar + search bar + product switcher heights.
It also tweaks a bit the padding values for the right sidebar menu to allow more characters to be shown on one line, which helps to have a smaller height of the sidebar menu in some cases, without impacting readability.