### PR TITLE
fix: patch SRI vulnerability detected by SecurityScorecard

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -175,6 +175,8 @@
     <script
       type="text/javascript"
       src="https://traefik.github.io/traefiklabs-header-app/main-v1.js"
+      integrity="sha384-cvU62C2FA/9xyOKfB/6GQY2ideHHGXZE+Cf5Zru0JttLJ/+EIxXzPW/LjgHY6M4P"
+      crossorigin="anonymous"
     ></script>
   </head>
 


### PR DESCRIPTION
Cf. https://github.com/traefik/infra/issues/8953

It also flags google fonts, but [SRI is not supported](https://github.com/google/fonts/issues/473)

Hash generated [here](https://www.srihash.org) or by running:
```shell
curl -s https://traefik.github.io/traefiklabs-header-app/main-v1.js | openssl dgst -sha384 -binary | openssl base64 -A 
```

<br>

Hash will be updated with every publish, see this [PR](https://github.com/traefik/traefiklabs-header-app/pull/62)